### PR TITLE
ls1043a : fix ddr memory size in device tree file.

### DIFF
--- a/include/arch/arm/arch/64/mode/kernel/vspace.h
+++ b/include/arch/arm/arch/64/mode/kernel/vspace.h
@@ -29,7 +29,11 @@ hw_asid_t getHWASID(asid_t asid);
 
 asid_map_t findMapForASID(asid_t asid);
 
+#ifdef __clang__
 static const region_t BOOT_RODATA mode_reserved_region[] = {};
+#else
+static const region_t BOOT_RODATA *mode_reserved_region = NULL;
+#endif
 
 #define PAR_EL1_MASK 0x0000fffffffff000ul
 #define GET_PAR_ADDR(x) ((x) & PAR_EL1_MASK)

--- a/tools/dts/ls1043a-rdb.dts
+++ b/tools/dts/ls1043a-rdb.dts
@@ -106,7 +106,7 @@
 
 	memory@80000000 {
 		device_type = "memory";
-		reg = <0x00 0x80000000 0x00 0x80000000>;
+		reg = <0x00 0x80000000 0x00 0x7B000000>;
 	};
 
 	reserved-memory {


### PR DESCRIPTION
Cannot access adresses after 0x7C000000, causing trap in kernel